### PR TITLE
Add basic CC1101 integration and unit tests

### DIFF
--- a/tests/integration/test_cc1101_sim.py
+++ b/tests/integration/test_cc1101_sim.py
@@ -1,0 +1,14 @@
+import pytest
+
+try:
+    import cc1101
+except Exception:  # pragma: no cover - library may not be present
+    cc1101 = None
+
+
+@pytest.mark.skipif(cc1101 is None, reason="CC1101 simulation not available")
+def test_cc1101_receives_sample_frame():
+    sim = cc1101.Simulator()
+    sample = bytes.fromhex("AABBCCDD")
+    sim.inject(sample)
+    assert sim.receive() == sample

--- a/tests/unit/test_transceiver_sx1276.py
+++ b/tests/unit/test_transceiver_sx1276.py
@@ -1,0 +1,41 @@
+import pytest
+
+class MockSX1276:
+    def __init__(self):
+        self.registers = {}
+        self.writes = []
+
+    def spi_write(self, address, value):
+        self.registers[address] = value
+        self.writes.append((address, value))
+
+    def spi_read(self, address):
+        return self.registers.get(address, 0)
+
+    def restart_rx(self):
+        # Standby mode
+        self.spi_write(0x01, 0b001)
+        # Clear FIFO
+        self.spi_write(0x3F, 1 << 4)
+        # Enable RX
+        self.spi_write(0x01, 0b101)
+
+    def get_rssi(self):
+        rssi = self.spi_read(0x11)
+        return -rssi // 2
+
+
+def test_rssi_conversion():
+    radio = MockSX1276()
+    radio.spi_write(0x11, 80)
+    assert radio.get_rssi() == -40
+
+
+def test_restart_rx_sequence():
+    radio = MockSX1276()
+    radio.restart_rx()
+    assert radio.writes == [
+        (0x01, 0b001),
+        (0x3F, 1 << 4),
+        (0x01, 0b101),
+    ]


### PR DESCRIPTION
## Summary
- add placeholder integration test for CC1101 simulation that validates sample frame reception when simulator is available
- add unit tests checking RSSI conversion and RX restart sequence for SX1276

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5f0c802a88326a40f503e5cb93e98