### PR TITLE
feat: add wmbus wrapper component

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ esphome:
 
 external_components:
   - source: github://SzczepanLeon/esphome-components@main
+    components: [wmbus]  # provides wmbus_radio and wmbus_meter
 
 esp32:
   board: heltec_wifi_lora_32_V2

--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -1,0 +1,18 @@
+import esphome.config_validation as cv
+
+CODEOWNERS = ["@SzczepanLeon", "@kubasaw"]
+
+# Ensure radio and meter components are available when referencing
+# this package from ESPHome's external_components section.
+DEPENDENCIES = ["wmbus_radio", "wmbus_meter"]
+
+# Re-export modules so users can access them via the wmbus namespace.
+from .. import wmbus_radio as radio  # noqa: F401
+from .. import wmbus_meter as meter  # noqa: F401
+
+__all__ = ["radio", "meter"]
+
+CONFIG_SCHEMA = cv.Schema({})
+
+async def to_code(config):
+    pass


### PR DESCRIPTION
## Summary
- add `wmbus` component wrapper that depends on `wmbus_radio` and `wmbus_meter`
- document using `components: [wmbus]` in the external components instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5f6e08554832680028aee96b5974b