### PR TITLE
Handle missing wmbus dependencies

### DIFF
--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -7,8 +7,15 @@ CODEOWNERS = ["@SzczepanLeon", "@kubasaw"]
 DEPENDENCIES = ["wmbus_radio", "wmbus_meter"]
 
 # Re-export modules so users can access them via the wmbus namespace.
-from .. import wmbus_radio as radio  # noqa: F401
-from .. import wmbus_meter as meter  # noqa: F401
+try:
+    from .. import wmbus_radio as radio  # noqa: F401
+except ImportError:  # pragma: no cover - runtime optional dependency
+    radio = None
+
+try:
+    from .. import wmbus_meter as meter  # noqa: F401
+except ImportError:  # pragma: no cover - runtime optional dependency
+    meter = None
 
 __all__ = ["radio", "meter"]
 


### PR DESCRIPTION
## Summary
- avoid import errors when `wmbus_radio` or `wmbus_meter` aren't installed by wrapping their imports in `try/except`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5f8be84248326aa2268d05c2255d4