### PR TITLE
feat: alias wmbus sensor to wmbus_meter

### DIFF
--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -17,7 +17,12 @@ try:
 except ImportError:  # pragma: no cover - runtime optional dependency
     meter = None
 
-__all__ = ["radio", "meter"]
+try:
+    from . import sensor  # noqa: F401
+except ImportError:  # pragma: no cover - runtime optional dependency
+    sensor = None
+
+__all__ = ["radio", "meter", "sensor"]
 
 CONFIG_SCHEMA = cv.Schema({})
 

--- a/components/wmbus/sensor/__init__.py
+++ b/components/wmbus/sensor/__init__.py
@@ -1,0 +1,7 @@
+"""WMBus sensor platform alias.
+
+This module re-exports the existing wmbus_meter sensor implementation so
+users can configure sensors with ``platform: wmbus``.
+"""
+
+from ...wmbus_meter.sensor import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- allow `platform: wmbus` sensors by re-exporting existing `wmbus_meter` implementation
- expose aliased sensor via `wmbus` package namespace

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5fa3e018c8326b846e378a498f3ef