### PR TITLE
Lazy load wmbus_common for wmbus_meter

### DIFF
--- a/components/wmbus/wmbus_meter/__init__.py
+++ b/components/wmbus/wmbus_meter/__init__.py
@@ -16,7 +16,11 @@ from esphome.components.mqtt import (
 )
 
 from ..wmbus_radio import RadioComponent
-from ...wmbus_common import validate_driver
+
+
+def validate_driver(value):
+    from ...wmbus_common import validate_driver as _validate_driver
+    return _validate_driver(value)
 
 CONF_METER_ID = "meter_id"
 CONF_RADIO_ID = "radio_id"

--- a/tests/unit/test_wmbus_common_dependency.py
+++ b/tests/unit/test_wmbus_common_dependency.py
@@ -157,7 +157,6 @@ def _import_meter(with_common: bool) -> None:
         sys.modules.update(original_modules)
 
 
-def test_wmbus_meter_requires_wmbus_common():
+def test_wmbus_meter_imports_without_wmbus_common():
     _import_meter(True)
-    with pytest.raises(ModuleNotFoundError):
-        _import_meter(False)
+    _import_meter(False)


### PR DESCRIPTION
## Summary
- Avoid importing `wmbus_common` at module import time for `wmbus_meter`
- Update tests for `wmbus_common` dependency check

## Testing
- `pytest tests/unit/test_wmbus_common_dependency.py tests/unit/test_sensor_wmbus_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68a627ab2af48326b889f6b42acefe97