### PR TITLE
Handle missing wmbus_common dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ components available. Once the dependency fix is in place, the sensor platform
 `wmbus` becomes an alias for `wmbus_meter`, so sensors can be defined using
 `platform: wmbus`.
 
+Make sure to also include the `wmbus_common` component in your
+`external_components` section.
+
 ## Minimal configuration
 
 Below is a minimal example showing how to configure `wmbus_radio` with the
@@ -18,7 +21,7 @@ required pins and `radio_type`:
 ```yaml
 external_components:
   - source: github://SzczepanLeon/esphome-components@main
-    components: [wmbus]
+    components: [wmbus, wmbus_common]
 
 wmbus_radio:
   radio_type: SX1276

--- a/components/wmbus/wmbus_meter/__init__.py
+++ b/components/wmbus/wmbus_meter/__init__.py
@@ -19,7 +19,12 @@ from ..wmbus_radio import RadioComponent
 
 
 def validate_driver(value):
-    from ...wmbus_common import validate_driver as _validate_driver
+    try:
+        from ...wmbus_common import validate_driver as _validate_driver
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "Komponent wmbus_common jest wymagany – dodaj go w sekcji external_components"
+        ) from e
     return _validate_driver(value)
 
 CONF_METER_ID = "meter_id"


### PR DESCRIPTION
## Summary
- clarify wmbus_common is required in README
- raise helpful error when wmbus_common isn't available

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6cb7e6f6883269fef0b5aec4a04f3